### PR TITLE
Support re-requested reviews

### DIFF
--- a/.github/workflows/github-slack-emoji-reaction.yml
+++ b/.github/workflows/github-slack-emoji-reaction.yml
@@ -14,6 +14,7 @@ jobs:
         - uses: actions/checkout@v3
           with:
             repository: jybp/github-slack-emoji-reaction
+            ref: 'v1.1.0'
         - uses: actions/setup-go@v4
           with:
             go-version: '1.20'

--- a/.github/workflows/github-slack-emoji-reaction.yml
+++ b/.github/workflows/github-slack-emoji-reaction.yml
@@ -3,7 +3,7 @@ on:
   pull_request_review:
     types: [submitted]
   pull_request:
-    types: [closed, reopened]
+    types: [closed, reopened, review_requested]
 permissions:
   pull-requests: read
 jobs:
@@ -27,3 +27,4 @@ jobs:
             EMOJI_COMMENTED: speech_balloon
             EMOJI_CLOSED: no_entry
             EMOJI_MERGED: large_purple_square
+            EMOJI_REVIEW_REQUESTED: arrows_counterclockwise

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
         - uses: actions/checkout@v3
           with:
             repository: jybp/github-slack-emoji-reaction
+            ref: 'v1.1.0'
         - uses: actions/setup-go@v4
           with:
             go-version: '1.20'
@@ -36,5 +37,5 @@ jobs:
             EMOJI_COMMENTED: speech_balloon
             EMOJI_CLOSED: no_entry
             EMOJI_MERGED: large_purple_square
-			EMOJI_REVIEW_REQUESTED: arrows_counterclockwise
+            EMOJI_REVIEW_REQUESTED: arrows_counterclockwise
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on:
   pull_request_review:
     types: [submitted]
   pull_request:
-    types: [closed, reopened]
+    types: [closed, reopened, review_requested]
 permissions:
   pull-requests: read
 jobs:

--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ jobs:
             EMOJI_COMMENTED: speech_balloon
             EMOJI_CLOSED: no_entry
             EMOJI_MERGED: large_purple_square
+			EMOJI_REVIEW_REQUESTED: arrows_counterclockwise
 ```

--- a/cmd/gser/main.go
+++ b/cmd/gser/main.go
@@ -93,12 +93,16 @@ func run() error {
 	if len(os.Getenv("EMOJI_MERGED")) > 0 {
 		slack.EmojiMerged = os.Getenv("EMOJI_MERGED")
 	}
+	if len(os.Getenv("EMOJI_REVIEW_REQUESTED")) > 0 {
+		slack.EmojiReviewRequested = os.Getenv("EMOJI_REVIEW_REQUESTED")
+	}
 	emojis := map[string]bool{
 		slack.EmojiApproved:         status.Approved,
 		slack.EmojiChangesRequested: status.ChangesRequested,
 		slack.EmojiCommented:        status.Commented,
 		slack.EmojiClosed:           status.Closed,
 		slack.EmojiMerged:           status.Merged,
+		slack.EmojiReviewRequested:  status.ReviewRequested,
 	}
 	slackAPI := slack.New(http.DefaultClient, slackBotToken)
 	if err := slackAPI.SetEmojis(ctx, url, channelIDs, emojis); err != nil {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -76,6 +76,9 @@ func (api API) PullRequestStatus(ctx context.Context, owner, repo string, number
 	latestByAuthor := map[int64]string{}
 	for i, review := range reviews {
 		log.Printf("review %d: %s\n", i, review.String())
+		if pr.GetUser().GetID() == review.User.GetID() {
+			continue // Skip PR author.
+		}
 		latestByAuthor[review.User.GetID()] = strings.ToLower(review.GetState())
 	}
 	// https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#get-all-requested-reviewers-for-a-pull-request

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -90,10 +90,13 @@ func (api API) PullRequestStatus(ctx context.Context, owner, repo string, number
 	// that he has been requested to review the PR again by the PR author and his old review should be
 	// considered dismissed.
 	for _, reviewer := range reviewers.Users {
-		if _, ok := latestByAuthor[reviewer.GetID()]; ok {
-			delete(latestByAuthor, reviewer.GetID())
+		closedOrMerged := status.Closed || status.Merged
+		_, ok := latestByAuthor[reviewer.GetID()]
+		if ok && !closedOrMerged {
+			// Only mark the PR has re-requesting a review if it's not closed/merged.
 			status.ReviewRequested = true
 		}
+		delete(latestByAuthor, reviewer.GetID())
 	}
 	for _, state := range latestByAuthor {
 		switch state {

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -16,9 +16,10 @@ var (
 
 	// Review state:
 	// https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#list-reviews-for-a-pull-request
-	EmojiApproved         = "white_check_mark" // ✅
-	EmojiChangesRequested = "x"                // ❌
-	EmojiCommented        = "speech_balloon"   // 💬
+	EmojiApproved         = "white_check_mark"        // ✅
+	EmojiChangesRequested = "x"                       // ❌
+	EmojiCommented        = "speech_balloon"          // 💬
+	EmojiReviewRequested  = "arrows_counterclockwise" // 🔄
 
 	// PR state:
 	// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request


### PR DESCRIPTION
Consider reviews as dismissed when the PR author re-requests a review from an author that already submitted one.
Adds a 🔄 emoji when a review is re-requested.